### PR TITLE
Deprecate repo, merged into silk-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED.
+
+This repository has been merged into [`silk-release`](https://github.com/cloudfoundry/silk-release). Please import this code from there.
+See related PRs and issues:
+- https://github.com/cloudfoundry/silk/issues/52
+- https://github.com/cloudfoundry/silk-release/pull/89
+
+
 # Silk
 
 > Note: This repository should be imported as `code.cloudfoundry.org/silk`.


### PR DESCRIPTION
This repo is being merged into silk-release. See the following:
- https://github.com/cloudfoundry/silk/issues/52
- https://github.com/cloudfoundry/silk-release/pull/89

[#185149418](https://www.pivotaltracker.com/story/show/185149418)